### PR TITLE
Centralize API endpoint paths and align document/certificate routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ dotenv.config();
  */
 export class D4Sign {
   private apiUrl: string;
+  private readonly accountEndpoint = '/account';
   private apiKey: string;
   private cryptKey?: string;
   private http: AxiosInstance;
@@ -88,7 +89,7 @@ export class D4Sign {
    */
   async getAccount(): Promise<AccountResponse> {
     try {
-      const response = await this.http.get('/account');
+      const response = await this.http.get(this.accountEndpoint);
       return response.data;
     } catch (error) {
       this.handleError(error);

--- a/src/modules/certificates/index.ts
+++ b/src/modules/certificates/index.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance } from 'axios';
-import { CertificateListResponse, D4SignResponse } from '../../types';
+import { D4SignResponse } from '../../types';
 
 /**
  * Certificate type enum
@@ -14,6 +14,7 @@ export enum CertificateType {
  */
 export class Certificates {
   private http: AxiosInstance;
+  private readonly endpoint = '/certificates';
 
   /**
    * Creates a new Certificates module instance
@@ -31,7 +32,7 @@ export class Certificates {
    */
   async find(uuidArquivo: string, keySigner: string): Promise<D4SignResponse> {
     const data = { key_signer: keySigner };
-    const response = await this.http.post(`/certificate/${uuidArquivo}/list`, data);
+    const response = await this.http.post(`${this.endpoint}/${uuidArquivo}/list`, data);
     return response.data;
   }
 
@@ -50,7 +51,7 @@ export class Certificates {
       document_number: documentNumber,
       pades: pades
     };
-    const response = await this.http.post(`/certificate/${uuidArquivo}/add`, data);
+    const response = await this.http.post(`${this.endpoint}/${uuidArquivo}/add`, data);
     return response.data;
   }
 }

--- a/src/modules/documents/index.ts
+++ b/src/modules/documents/index.ts
@@ -9,6 +9,7 @@ import { D4SignResponse, DocumentDetailResponse, DocumentListResponse } from '..
  */
 export class Documents {
   private http: AxiosInstance;
+  private readonly endpoint = '/documents';
 
   /**
    * Creates a new Documents module instance
@@ -32,7 +33,7 @@ export class Documents {
       'password-code': JSON.stringify(code),
       'key-signer': JSON.stringify(keySigner)
     };
-    const response = await this.http.post(`/documents/${documentKey}/changepasswordcode`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/changepasswordcode`, data);
     return response.data;
   }
 
@@ -49,7 +50,7 @@ export class Documents {
       'sms-number': JSON.stringify(sms),
       'key-signer': JSON.stringify(keySigner)
     };
-    const response = await this.http.post(`/documents/${documentKey}/changesmsnumber`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/changesmsnumber`, data);
     return response.data;
   }
 
@@ -64,7 +65,7 @@ export class Documents {
       'email-signer': JSON.stringify(email),
       'key-signer': JSON.stringify(key)
     };
-    const response = await this.http.post(`/documents/${documentKey}/removeemaillist`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/removeemaillist`, data);
     return response.data;
   }
 
@@ -81,7 +82,7 @@ export class Documents {
       'email-after': JSON.stringify(emailAfter),
       'key-signer': JSON.stringify(key)
     };
-    const response = await this.http.post(`/documents/${documentKey}/changeemail`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/changeemail`, data);
     return response.data;
   }
 
@@ -92,9 +93,17 @@ export class Documents {
    */
   async find(documentKey: string = '', page: number = 1): Promise<DocumentListResponse> {
     const params: any = { pg: page };
-    const url = documentKey ? `/documents/${documentKey}` : '/documents';
+    const url = documentKey ? `${this.endpoint}/${documentKey}` : this.endpoint;
     const response = await this.http.get(url, { params });
     return response.data;
+  }
+
+  /**
+   * List documents
+   * @param page - Optional page number
+   */
+  async list(page: number = 1): Promise<DocumentListResponse> {
+    return this.find('', page);
   }
 
   /**
@@ -102,7 +111,7 @@ export class Documents {
    * @param documentKey - UUID of the document
    */
   async listSignatures(documentKey: string): Promise<D4SignResponse> {
-    const response = await this.http.get(`/documents/${documentKey}/list`);
+    const response = await this.http.get(`${this.endpoint}/${documentKey}/list`);
     return response.data;
   }
 
@@ -113,7 +122,7 @@ export class Documents {
    */
   async status(status: string, page: number = 1): Promise<D4SignResponse> {
     const params = { pg: page };
-    const response = await this.http.get(`/documents/${status}/status`, { params });
+    const response = await this.http.get(`${this.endpoint}/${status}/status`, { params });
     return response.data;
   }
 
@@ -125,7 +134,8 @@ export class Documents {
    */
   async safe(safeKey: string, uuidFolder: string = '', page: number = 1): Promise<D4SignResponse> {
     const params = { pg: page };
-    const response = await this.http.get(`/documents/${safeKey}/safe/${uuidFolder}`, { params });
+    const folderSegment = uuidFolder ? `/${uuidFolder}` : '';
+    const response = await this.http.get(`${this.endpoint}/${safeKey}/safe${folderSegment}`, { params });
     return response.data;
   }
 
@@ -144,7 +154,7 @@ export class Documents {
     if (uuidFolder) {
       formData.append('uuid_folder', JSON.stringify(uuidFolder));
     }
-    const response = await this.http.post(`/documents/${uuidSafe}/upload`, formData, {
+    const response = await this.http.post(`${this.endpoint}/${uuidSafe}/upload`, formData, {
       headers: {
         ...formData.getHeaders(),
       },
@@ -168,7 +178,7 @@ export class Documents {
       name: name,
       uuid_folder: JSON.stringify(uuidFolder)
     };
-    const response = await this.http.post(`/documents/${uuidSafe}/uploadbinary`, data);
+    const response = await this.http.post(`${this.endpoint}/${uuidSafe}/uploadbinary`, data);
     return response.data;
   }
 
@@ -186,7 +196,7 @@ export class Documents {
       mime_type: mimeType,
       name: name
     };
-    const response = await this.http.post(`/documents/${uuidMaster}/uploadslavebinary`, data);
+    const response = await this.http.post(`${this.endpoint}/${uuidMaster}/uploadslavebinary`, data);
     return response.data;
   }
 
@@ -201,7 +211,7 @@ export class Documents {
     const fileContent = fs.readFileSync(filePath);
     const fileName = path.basename(filePath);
     formData.append('file', fileContent, fileName);
-    const response = await this.http.post(`/documents/${uuidOriginalFile}/uploadslave`, formData, {
+    const response = await this.http.post(`${this.endpoint}/${uuidOriginalFile}/uploadslave`, formData, {
       headers: {
         ...formData.getHeaders(),
       },
@@ -216,7 +226,7 @@ export class Documents {
    */
   async cancel(documentKey: string, comment: string = ''): Promise<D4SignResponse> {
     const data = { comment: JSON.stringify(comment) };
-    const response = await this.http.post(`/documents/${documentKey}/cancel`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/cancel`, data);
     return response.data;
   }
 
@@ -231,7 +241,7 @@ export class Documents {
       signers: JSON.stringify(signers),
       skip_email: JSON.stringify(skipEmail)
     };
-    const response = await this.http.post(`/documents/${documentKey}/createlist`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/createlist`, data);
     return response.data;
   }
 
@@ -248,7 +258,7 @@ export class Documents {
       name_document: JSON.stringify(nameDocument),
       uuid_folder: JSON.stringify(uuidFolder)
     };
-    const response = await this.http.post(`/documents/${documentKey}/makedocumentbytemplate`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/makedocumentbytemplate`, data);
     return response.data;
   }
 
@@ -265,7 +275,7 @@ export class Documents {
       name_document: JSON.stringify(nameDocument),
       uuid_folder: JSON.stringify(uuidFolder)
     };
-    const response = await this.http.post(`/documents/${documentKey}/makedocumentbytemplateword`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/makedocumentbytemplateword`, data);
     return response.data;
   }
 
@@ -276,7 +286,7 @@ export class Documents {
    */
   async webhookAdd(documentKey: string, url: string): Promise<D4SignResponse> {
     const data = { url: JSON.stringify(url) };
-    const response = await this.http.post(`/documents/${documentKey}/webhooks`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/webhooks`, data);
     return response.data;
   }
 
@@ -285,7 +295,7 @@ export class Documents {
    * @param documentKey - UUID of the document
    */
   async webhookList(documentKey: string): Promise<D4SignResponse> {
-    const response = await this.http.get(`/documents/${documentKey}/webhooks`);
+    const response = await this.http.get(`${this.endpoint}/${documentKey}/webhooks`);
     return response.data;
   }
 
@@ -302,7 +312,7 @@ export class Documents {
       workflow: JSON.stringify(workflow),
       skip_email: JSON.stringify(skipEmail)
     };
-    const response = await this.http.post(`/documents/${documentKey}/sendtosigner`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/sendtosigner`, data);
     return response.data;
   }
 
@@ -323,7 +333,7 @@ export class Documents {
       documentation: JSON.stringify(documentation),
       birthday: JSON.stringify(birthday)
     };
-    const response = await this.http.post(`/documents/${documentKey}/addinfo`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/addinfo`, data);
     return response.data;
   }
 
@@ -338,7 +348,7 @@ export class Documents {
       email: JSON.stringify(email),
       key_signer: JSON.stringify(key)
     };
-    const response = await this.http.post(`/documents/${documentKey}/resend`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/resend`, data);
     return response.data;
   }
 
@@ -349,7 +359,7 @@ export class Documents {
    */
   async getFileUrl(documentKey: string, type: string): Promise<D4SignResponse> {
     const data = { type: JSON.stringify(type) };
-    const response = await this.http.post(`/documents/${documentKey}/download`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/download`, data);
     return response.data;
   }
 
@@ -369,7 +379,7 @@ export class Documents {
       name: name,
       uuid_folder: JSON.stringify(uuidFolder)
     };
-    const response = await this.http.post(`/documents/${uuidSafe}/uploadhash`, data);
+    const response = await this.http.post(`${this.endpoint}/${uuidSafe}/uploadhash`, data);
     return response.data;
   }
 
@@ -378,7 +388,7 @@ export class Documents {
    * @param documentUuid - UUID of the document
    */
   async getDocument(documentUuid: string): Promise<DocumentDetailResponse> {
-    const response = await this.http.get(`/documents/${documentUuid}`);
+    const response = await this.http.get(`${this.endpoint}/${documentUuid}`);
     return response.data;
   }
 }

--- a/src/modules/signatures/index.ts
+++ b/src/modules/signatures/index.ts
@@ -29,6 +29,7 @@ export interface Signer {
  */
 export class Signatures {
   private http: AxiosInstance;
+  private readonly endpoint = '/documents';
 
   /**
    * Creates a new Signatures module instance
@@ -48,7 +49,7 @@ export class Signatures {
       'password-code': JSON.stringify(code),
       'key-signer': JSON.stringify(keySigner)
     };
-    const response = await this.http.post(`/documents/${documentKey}/changepasswordcode`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/changepasswordcode`, data);
     return response.data;
   }
 
@@ -61,7 +62,7 @@ export class Signatures {
       'sms-number': JSON.stringify(sms),
       'key-signer': JSON.stringify(keySigner)
     };
-    const response = await this.http.post(`/documents/${documentKey}/changesmsnumber`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/changesmsnumber`, data);
     return response.data;
   }
 
@@ -73,7 +74,7 @@ export class Signatures {
       'email-signer': JSON.stringify(email),
       'key-signer': JSON.stringify(key)
     };
-    const response = await this.http.post(`/documents/${documentKey}/removeemaillist`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/removeemaillist`, data);
     return response.data;
   }
 
@@ -86,7 +87,7 @@ export class Signatures {
       'email-after': JSON.stringify(emailAfter),
       'key-signer': JSON.stringify(key)
     };
-    const response = await this.http.post(`/documents/${documentKey}/changeemail`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/changeemail`, data);
     return response.data;
   }
 
@@ -94,7 +95,7 @@ export class Signatures {
    * List signatures for a document
    */
   async listSignatures(documentKey: string): Promise<D4SignResponse> {
-    const response = await this.http.get(`/documents/${documentKey}/list`);
+    const response = await this.http.get(`${this.endpoint}/${documentKey}/list`);
     return response.data;
   }
 
@@ -103,7 +104,7 @@ export class Signatures {
    */
   async status(status: string, page: number = 1): Promise<D4SignResponse> {
     const params = { pg: page };
-    const response = await this.http.get(`/documents/${status}/status`, { params });
+    const response = await this.http.get(`${this.endpoint}/${status}/status`, { params });
     return response.data;
   }
 
@@ -115,7 +116,7 @@ export class Signatures {
       signers: JSON.stringify(signers),
       skip_email: JSON.stringify(skipEmail)
     };
-    const response = await this.http.post(`/documents/${documentKey}/createlist`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/createlist`, data);
     return response.data;
   }
 
@@ -130,7 +131,7 @@ export class Signatures {
       documentation: JSON.stringify(documentation),
       birthday: JSON.stringify(birthday)
     };
-    const response = await this.http.post(`/documents/${documentKey}/addinfo`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/addinfo`, data);
     return response.data;
   }
 
@@ -142,7 +143,7 @@ export class Signatures {
       email: JSON.stringify(email),
       key_signer: JSON.stringify(key)
     };
-    const response = await this.http.post(`/documents/${documentKey}/resend`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/resend`, data);
     return response.data;
   }
 }

--- a/src/modules/webhooks/index.ts
+++ b/src/modules/webhooks/index.ts
@@ -6,6 +6,7 @@ import { D4SignResponse } from '../../types';
  */
 export class Webhooks {
   private http: AxiosInstance;
+  private readonly endpoint = '/documents';
 
   /**
    * Creates a new Webhooks module instance
@@ -23,7 +24,7 @@ export class Webhooks {
    */
   async add(documentKey: string, url: string): Promise<D4SignResponse> {
     const data = { url: JSON.stringify(url) };
-    const response = await this.http.post(`/documents/${documentKey}/webhooks`, data);
+    const response = await this.http.post(`${this.endpoint}/${documentKey}/webhooks`, data);
     return response.data;
   }
 
@@ -32,7 +33,7 @@ export class Webhooks {
    * @param documentKey - UUID of the document
    */
   async list(documentKey: string): Promise<D4SignResponse> {
-    const response = await this.http.get(`/documents/${documentKey}/webhooks`);
+    const response = await this.http.get(`${this.endpoint}/${documentKey}/webhooks`);
     return response.data;
   }
 }


### PR DESCRIPTION
### Motivation
- Avoid duplicated hardcoded paths and reduce drift between modules by centralizing base endpoint segments. 
- Align certificate routes with the API naming convention (plural) used elsewhere in the client. 
- Fix incorrect `documents.safe` URL assembly that produced an extra trailing slash when no folder is provided. 
- Restore a `documents.list(...)` compatibility helper to match existing public API usage and test expectations.

### Description
- Added `endpoint` constants to `Documents`, `Signatures`, `Webhooks`, and `Certificates`, and replaced inline `/documents`/`/certificate` usages with `${this.endpoint}` calls. 
- Changed certificate endpoints from `/certificate/...` to `/certificates/...` and removed an unused type import in `src/modules/certificates/index.ts`. 
- Implemented `documents.list(page?)` as a wrapper over `find('', page)` to preserve compatibility. 
- Fixed `documents.safe` to conditionally append the folder segment (`/safe` or `/safe/{folder}`) and centralized the account path in `src/index.ts` via `accountEndpoint`.

### Testing
- Ran `npm test -- --runInBand` and all tests passed (`4 passed, 4 total`).
- Ran `npm run build` and TypeScript compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c5f0a5a4832b9e3121a4d7be87d9)